### PR TITLE
feat: 특정 섹션 내용 가져오는 API 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.jetbrains:annotations:16.0.2'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'com.h2database:h2'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/lubycon/curriculum/blog/domain/Blog.java
+++ b/src/main/java/com/lubycon/curriculum/blog/domain/Blog.java
@@ -24,9 +24,6 @@ public class Blog extends BaseTimeEntity {
   @Column(name = "id", updatable = false)
   private Long id;
 
-  @Column(name = "section_id")
-  private Long sectionId;
-
   @Column(name = "title")
   private String title;
 
@@ -38,9 +35,9 @@ public class Blog extends BaseTimeEntity {
   private Section section;
 
   @Builder
-  public Blog(Long sectionId, String title, String link) {
-    this.sectionId = sectionId;
+  public Blog(String title, String link, Section section) {
     this.title = title;
     this.link = link;
+    this.section = section;
   }
 }

--- a/src/main/java/com/lubycon/curriculum/blog/domain/Blog.java
+++ b/src/main/java/com/lubycon/curriculum/blog/domain/Blog.java
@@ -24,10 +24,10 @@ public class Blog extends BaseTimeEntity {
   @Column(name = "id", updatable = false)
   private Long id;
 
-  @Column(name = "title")
+  @Column(name = "title", nullable = false)
   private String title;
 
-  @Column(name = "link")
+  @Column(name = "link", nullable = false)
   private String link;
 
   @ManyToOne

--- a/src/main/java/com/lubycon/curriculum/curriculum/domain/Curriculum.java
+++ b/src/main/java/com/lubycon/curriculum/curriculum/domain/Curriculum.java
@@ -13,6 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -40,4 +41,13 @@ public class Curriculum extends BaseTimeEntity {
 
   @OneToMany(mappedBy = "curriculum", fetch = FetchType.LAZY)
   private List<Section> sections;
+
+  @Builder
+  public Curriculum(String title, String description, String thumbnail,
+      List<Section> sections) {
+    this.title = title;
+    this.description = description;
+    this.thumbnail = thumbnail;
+    this.sections = sections;
+  }
 }

--- a/src/main/java/com/lubycon/curriculum/section/api/SectionApi.java
+++ b/src/main/java/com/lubycon/curriculum/section/api/SectionApi.java
@@ -1,0 +1,24 @@
+package com.lubycon.curriculum.section.api;
+
+import com.lubycon.curriculum.section.dto.SectionResponse;
+import com.lubycon.curriculum.section.service.SectionService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+public class SectionApi {
+
+  private final SectionService sectionService;
+
+  @GetMapping("/curriculums/{curriculumId}/sections/{order}")
+  public ResponseEntity<SectionResponse> getSection(
+      @PathVariable long curriculumId, @PathVariable int order) {
+
+    return ResponseEntity.ok()
+        .body(sectionService.findSection(curriculumId, order));
+  }
+}

--- a/src/main/java/com/lubycon/curriculum/section/domain/IntroSection.java
+++ b/src/main/java/com/lubycon/curriculum/section/domain/IntroSection.java
@@ -13,6 +13,7 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -36,4 +37,11 @@ public class IntroSection {
   @OneToOne
   @JoinColumn(name = "curriculum_id", referencedColumnName = "id", insertable = false, updatable = false)
   private Curriculum curriculum;
+
+  @Builder
+  public IntroSection(IntroDescription description,
+      Curriculum curriculum) {
+    this.description = description;
+    this.curriculum = curriculum;
+  }
 }

--- a/src/main/java/com/lubycon/curriculum/section/domain/Section.java
+++ b/src/main/java/com/lubycon/curriculum/section/domain/Section.java
@@ -23,11 +23,13 @@ import lombok.NoArgsConstructor;
 @Entity
 public class Section extends BaseTimeEntity {
 
-
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(name = "id", updatable = false)
   private Long id;
+
+  @Column(name = "title")
+  private String title;
 
   @Column(name = "description")
   private String description;
@@ -46,7 +48,11 @@ public class Section extends BaseTimeEntity {
   private Curriculum curriculum;
 
   @Builder
-  public Section(String description) {
+  public Section(String title, String description, Integer order,
+      Curriculum curriculum) {
+    this.title = title;
     this.description = description;
+    this.order = order;
+    this.curriculum = curriculum;
   }
 }

--- a/src/main/java/com/lubycon/curriculum/section/domain/Section.java
+++ b/src/main/java/com/lubycon/curriculum/section/domain/Section.java
@@ -28,13 +28,13 @@ public class Section extends BaseTimeEntity {
   @Column(name = "id", updatable = false)
   private Long id;
 
-  @Column(name = "title")
+  @Column(name = "title", nullable = false)
   private String title;
 
   @Column(name = "description")
   private String description;
 
-  @Column(name = "order_by")
+  @Column(name = "order_by", nullable = false)
   private Integer order;
 
   @Column(name = "is_hide", nullable = false, columnDefinition = "boolean default false")

--- a/src/main/java/com/lubycon/curriculum/section/dto/BlogResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/BlogResponse.java
@@ -2,11 +2,15 @@ package com.lubycon.curriculum.section.dto;
 
 import com.lubycon.curriculum.blog.domain.Blog;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 
 @Getter
 public class BlogResponse {
 
+  @NotNull
   private final String title;
+
+  @NotNull
   private final String link;
 
   public BlogResponse(Blog blog) {

--- a/src/main/java/com/lubycon/curriculum/section/dto/BlogResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/BlogResponse.java
@@ -1,10 +1,16 @@
 package com.lubycon.curriculum.section.dto;
 
+import com.lubycon.curriculum.blog.domain.Blog;
 import lombok.Getter;
 
 @Getter
 public class BlogResponse {
 
-  private String title;
-  private String link;
+  private final String title;
+  private final String link;
+
+  public BlogResponse(Blog blog) {
+    this.title = blog.getTitle();
+    this.link = blog.getLink();
+  }
 }

--- a/src/main/java/com/lubycon/curriculum/section/dto/BlogResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/BlogResponse.java
@@ -1,0 +1,10 @@
+package com.lubycon.curriculum.section.dto;
+
+import lombok.Getter;
+
+@Getter
+public class BlogResponse {
+
+  private String title;
+  private String link;
+}

--- a/src/main/java/com/lubycon/curriculum/section/dto/NextSectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/NextSectionResponse.java
@@ -1,0 +1,10 @@
+package com.lubycon.curriculum.section.dto;
+
+import lombok.Getter;
+
+@Getter
+public class NextSectionResponse {
+
+  private long id;
+  private String title;
+}

--- a/src/main/java/com/lubycon/curriculum/section/dto/NextSectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/NextSectionResponse.java
@@ -1,10 +1,20 @@
 package com.lubycon.curriculum.section.dto;
 
+import com.lubycon.curriculum.section.domain.Section;
 import lombok.Getter;
 
 @Getter
 public class NextSectionResponse {
 
-  private long id;
-  private String title;
+  private final long id;
+  private final String title;
+
+  private NextSectionResponse(long id, String title) {
+    this.id = id;
+    this.title = title;
+  }
+
+  public static NextSectionResponse fromEntity(Section section) {
+    return new NextSectionResponse(section.getId(), section.getTitle());
+  }
 }

--- a/src/main/java/com/lubycon/curriculum/section/dto/NextSectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/NextSectionResponse.java
@@ -2,14 +2,17 @@ package com.lubycon.curriculum.section.dto;
 
 import com.lubycon.curriculum.section.domain.Section;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 
 @Getter
 public class NextSectionResponse {
 
   private final long id;
+
+  @NotNull
   private final String title;
 
-  private NextSectionResponse(long id, String title) {
+  private NextSectionResponse(long id, @NotNull String title) {
     this.id = id;
     this.title = title;
   }

--- a/src/main/java/com/lubycon/curriculum/section/dto/PrevSectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/PrevSectionResponse.java
@@ -1,10 +1,20 @@
 package com.lubycon.curriculum.section.dto;
 
+import com.lubycon.curriculum.section.domain.Section;
 import lombok.Getter;
 
 @Getter
 public class PrevSectionResponse {
 
-  private long id;
-  private String title;
+  private final long id;
+  private final String title;
+
+  private PrevSectionResponse(long id, String title) {
+    this.id = id;
+    this.title = title;
+  }
+
+  public static PrevSectionResponse fromEntity(Section section) {
+    return new PrevSectionResponse(section.getId(), section.getTitle());
+  }
 }

--- a/src/main/java/com/lubycon/curriculum/section/dto/PrevSectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/PrevSectionResponse.java
@@ -1,0 +1,10 @@
+package com.lubycon.curriculum.section.dto;
+
+import lombok.Getter;
+
+@Getter
+public class PrevSectionResponse {
+
+  private long id;
+  private String title;
+}

--- a/src/main/java/com/lubycon/curriculum/section/dto/PrevSectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/PrevSectionResponse.java
@@ -2,14 +2,17 @@ package com.lubycon.curriculum.section.dto;
 
 import com.lubycon.curriculum.section.domain.Section;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
 
 @Getter
 public class PrevSectionResponse {
 
   private final long id;
+
+  @NotNull
   private final String title;
 
-  private PrevSectionResponse(long id, String title) {
+  private PrevSectionResponse(long id, @NotNull String title) {
     this.id = id;
     this.title = title;
   }

--- a/src/main/java/com/lubycon/curriculum/section/dto/SectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/SectionResponse.java
@@ -9,16 +9,18 @@ public class SectionResponse {
 
   private final String title;
   private final String description;
+  private final int order;
   private final List<BlogResponse> blogs;
   private final NextSectionResponse nextSection;
   private final PrevSectionResponse prevSection;
 
   @Builder
-  public SectionResponse(String title, String description,
+  public SectionResponse(String title, String description, int order,
       List<BlogResponse> blogs, NextSectionResponse nextSection,
       PrevSectionResponse prevSection) {
     this.title = title;
     this.description = description;
+    this.order = order;
     this.blogs = blogs;
     this.nextSection = nextSection;
     this.prevSection = prevSection;

--- a/src/main/java/com/lubycon/curriculum/section/dto/SectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/SectionResponse.java
@@ -1,16 +1,26 @@
 package com.lubycon.curriculum.section.dto;
 
 import java.util.List;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
-@Setter
 public class SectionResponse {
 
-  private String title;
-  private String description;
-  private List<BlogResponse> blogs;
-  private NextSectionResponse nextSection;
-  private PrevSectionResponse prevSection;
+  private final String title;
+  private final String description;
+  private final List<BlogResponse> blogs;
+  private final NextSectionResponse nextSection;
+  private final PrevSectionResponse prevSection;
+
+  @Builder
+  public SectionResponse(String title, String description,
+      List<BlogResponse> blogs, NextSectionResponse nextSection,
+      PrevSectionResponse prevSection) {
+    this.title = title;
+    this.description = description;
+    this.blogs = blogs;
+    this.nextSection = nextSection;
+    this.prevSection = prevSection;
+  }
 }

--- a/src/main/java/com/lubycon/curriculum/section/dto/SectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/SectionResponse.java
@@ -3,21 +3,33 @@ package com.lubycon.curriculum.section.dto;
 import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 @Getter
 public class SectionResponse {
 
+  @NotNull
   private final String title;
+
+  @Nullable
   private final String description;
+
   private final int order;
+
+  @NotNull
   private final List<BlogResponse> blogs;
+
+  @Nullable
   private final NextSectionResponse nextSection;
+
+  @Nullable
   private final PrevSectionResponse prevSection;
 
   @Builder
-  public SectionResponse(String title, String description, int order,
-      List<BlogResponse> blogs, NextSectionResponse nextSection,
-      PrevSectionResponse prevSection) {
+  public SectionResponse(@NotNull String title, @Nullable String description, int order,
+      @NotNull List<BlogResponse> blogs, @Nullable NextSectionResponse nextSection,
+      @Nullable PrevSectionResponse prevSection) {
     this.title = title;
     this.description = description;
     this.order = order;

--- a/src/main/java/com/lubycon/curriculum/section/dto/SectionResponse.java
+++ b/src/main/java/com/lubycon/curriculum/section/dto/SectionResponse.java
@@ -1,0 +1,16 @@
+package com.lubycon.curriculum.section.dto;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class SectionResponse {
+
+  private String title;
+  private String description;
+  private List<BlogResponse> blogs;
+  private NextSectionResponse nextSection;
+  private PrevSectionResponse prevSection;
+}

--- a/src/main/java/com/lubycon/curriculum/section/model/IntroDescription.java
+++ b/src/main/java/com/lubycon/curriculum/section/model/IntroDescription.java
@@ -2,8 +2,12 @@ package com.lubycon.curriculum.section.model;
 
 import javax.persistence.Column;
 import javax.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
 @Embeddable
 public class IntroDescription {
@@ -14,4 +18,9 @@ public class IntroDescription {
   @Column(name = "summary")
   private String summary;
 
+  @Builder
+  public IntroDescription(String description, String summary) {
+    this.description = description;
+    this.summary = summary;
+  }
 }

--- a/src/main/java/com/lubycon/curriculum/section/repository/SectionRepository.java
+++ b/src/main/java/com/lubycon/curriculum/section/repository/SectionRepository.java
@@ -1,8 +1,11 @@
 package com.lubycon.curriculum.section.repository;
 
 import com.lubycon.curriculum.section.domain.Section;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface SectionRepository extends JpaRepository<Section, Long> {
+
+  Optional<Section> findByCurriculumIdAndOrder(long curriculumId, int order);
 
 }

--- a/src/main/java/com/lubycon/curriculum/section/service/SectionService.java
+++ b/src/main/java/com/lubycon/curriculum/section/service/SectionService.java
@@ -1,7 +1,12 @@
 package com.lubycon.curriculum.section.service;
 
+import com.lubycon.curriculum.section.domain.Section;
+import com.lubycon.curriculum.section.dto.BlogResponse;
+import com.lubycon.curriculum.section.dto.NextSectionResponse;
+import com.lubycon.curriculum.section.dto.PrevSectionResponse;
 import com.lubycon.curriculum.section.dto.SectionResponse;
 import com.lubycon.curriculum.section.repository.SectionRepository;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,8 +18,36 @@ public class SectionService {
   private final SectionRepository sectionRepository;
 
   @Transactional(readOnly = true)
-  public SectionResponse findSection(long curriculumId, long sectionId) {
-    return null;
+  public SectionResponse findSection(long curriculumId, int order) {
+    Section section = findById(curriculumId, order);
+    PrevSectionResponse prevSection = findPrevSection(curriculumId, order);
+    NextSectionResponse nextSection = findNextSection(curriculumId, order);
+
+    return SectionResponse.builder()
+        .title(section.getTitle())
+        .description(section.getDescription())
+        .blogs(section.getBlogs().stream()
+            .map(BlogResponse::new)
+            .collect(Collectors.toList()))
+        .prevSection(prevSection)
+        .nextSection(nextSection)
+        .build();
   }
 
+  private Section findById(long curriculumId, int order) {
+    return sectionRepository.findByCurriculumIdAndOrder(curriculumId, order)
+        .orElseThrow(RuntimeException::new); // FIXME: 예외 바꾸기
+  }
+
+  private NextSectionResponse findNextSection(long curriculumId, int order) {
+    return sectionRepository.findByCurriculumIdAndOrder(curriculumId, order + 1)
+        .map(NextSectionResponse::fromEntity)
+        .orElse(null);
+  }
+
+  private PrevSectionResponse findPrevSection(long curriculumId, int order) {
+    return sectionRepository.findByCurriculumIdAndOrder(curriculumId, order - 1)
+        .map(PrevSectionResponse::fromEntity)
+        .orElse(null);
+  }
 }

--- a/src/main/java/com/lubycon/curriculum/section/service/SectionService.java
+++ b/src/main/java/com/lubycon/curriculum/section/service/SectionService.java
@@ -1,0 +1,20 @@
+package com.lubycon.curriculum.section.service;
+
+import com.lubycon.curriculum.section.dto.SectionResponse;
+import com.lubycon.curriculum.section.repository.SectionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+public class SectionService {
+
+  private final SectionRepository sectionRepository;
+
+  @Transactional(readOnly = true)
+  public SectionResponse findSection(long curriculumId, long sectionId) {
+    return null;
+  }
+
+}

--- a/src/main/java/com/lubycon/curriculum/section/service/SectionService.java
+++ b/src/main/java/com/lubycon/curriculum/section/service/SectionService.java
@@ -26,6 +26,7 @@ public class SectionService {
     return SectionResponse.builder()
         .title(section.getTitle())
         .description(section.getDescription())
+        .order(section.getOrder())
         .blogs(section.getBlogs().stream()
             .map(BlogResponse::new)
             .collect(Collectors.toList()))

--- a/src/test/java/com/lubycon/curriculum/base/ApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/base/ApiTest.java
@@ -1,0 +1,40 @@
+package com.lubycon.curriculum.base;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jdk.nashorn.internal.ir.annotations.Ignore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(SpringExtension.class)
+@SpringBootTest
+@AutoConfigureMockMvc
+@Ignore
+public class ApiTest {
+
+  @Autowired
+  protected MockMvc mockMvc;
+
+  @Autowired
+  protected ObjectMapper objectMapper;
+
+  @Autowired
+  private WebApplicationContext context;
+
+  @BeforeEach
+  public void mockMvcSetUp() {
+    this.mockMvc = MockMvcBuilders.webAppContextSetup(context)
+        .addFilters(new CharacterEncodingFilter("UTF-8", true))
+        .alwaysDo(print())
+        .build();
+  }
+}

--- a/src/test/java/com/lubycon/curriculum/base/RepositoryTest.java
+++ b/src/test/java/com/lubycon/curriculum/base/RepositoryTest.java
@@ -1,15 +1,15 @@
 package com.lubycon.curriculum.base;
 
-import jdk.nashorn.internal.ir.annotations.Ignore;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.transaction.annotation.Transactional;
 
+@Transactional
 @ExtendWith(SpringExtension.class)
 @DataJpaTest
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
-@Ignore
+@Disabled
 public class RepositoryTest {
 
 }

--- a/src/test/java/com/lubycon/curriculum/blog/BlogRepositoryTest.java
+++ b/src/test/java/com/lubycon/curriculum/blog/BlogRepositoryTest.java
@@ -5,36 +5,23 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.lubycon.curriculum.base.RepositoryTest;
 import com.lubycon.curriculum.blog.domain.Blog;
 import com.lubycon.curriculum.blog.repository.BlogRepository;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
 
 class BlogRepositoryTest extends RepositoryTest {
 
   @Autowired
   private BlogRepository blogRepository;
 
-  private Blog blog;
-
-  private static final String TITLE = "JUnit5의 기본적인 사용법들";
-  private static final String LINK = "https://shinsunyoung.tistory.com/100";
-
-  @BeforeEach
-  public void setUp() {
-
-    blog = blogRepository.save(Blog.builder()
-        .title(TITLE)
-        .link(LINK)
-        .build());
-  }
-
+  @Sql("/make-curriculum.sql")
   @DisplayName("findById() 테스트")
   @Test
   public void findById() {
-    Blog link = blogRepository.findById(this.blog.getId()).get();
+    Blog link = blogRepository.findById(1L).get();
 
-    assertThat(link.getTitle()).isEqualTo(TITLE);
-    assertThat(link.getLink()).isEqualTo(LINK);
+    assertThat(link.getTitle()).isEqualTo("1번 섹션의 블로그 제목1");
+    assertThat(link.getLink()).isEqualTo("1번 섹션의 블로그 링크1");
   }
 }

--- a/src/test/java/com/lubycon/curriculum/curriculum/repository/CurriculumRepositoryTest.java
+++ b/src/test/java/com/lubycon/curriculum/curriculum/repository/CurriculumRepositoryTest.java
@@ -9,12 +9,14 @@ import com.lubycon.curriculum.section.domain.Section;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
 
 class CurriculumRepositoryTest extends RepositoryTest {
 
   @Autowired
   private CurriculumRepository curriculumRepository;
 
+  @Sql("/make-curriculum.sql")
   @DisplayName("findById() 테스트")
   @Test
   public void findById() {
@@ -22,10 +24,10 @@ class CurriculumRepositoryTest extends RepositoryTest {
     IntroSection introSection = curriculum.getIntroSection();
     Section firstSection = curriculum.getSections().get(0);
 
-    assertThat(curriculum.getTitle()).isEqualTo("제목");
-    assertThat(curriculum.getThumbnail()).isEqualTo("썸네일");
-    assertThat(firstSection.getDescription()).isEqualTo("설명");
-    assertThat(introSection.getDescription().getSummary()).isEqualTo("핵심 설명");
+    assertThat(curriculum.getTitle()).isEqualTo("1번 커리큘럼의 제목");
+    assertThat(curriculum.getThumbnail()).isEqualTo("1번 커리큘럼의 썸네일");
+    assertThat(firstSection.getDescription()).isEqualTo("1번 커리큘럼의 1번 섹션입니다.");
+    assertThat(introSection.getDescription().getSummary()).isEqualTo("1번 커리큘럼의 핵심 설명");
   }
 
 }

--- a/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
@@ -5,97 +5,30 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.lubycon.curriculum.base.ApiTest;
-import com.lubycon.curriculum.blog.domain.Blog;
-import com.lubycon.curriculum.blog.repository.BlogRepository;
-import com.lubycon.curriculum.curriculum.domain.Curriculum;
-import com.lubycon.curriculum.curriculum.repository.CurriculumRepository;
-import com.lubycon.curriculum.section.domain.IntroSection;
-import com.lubycon.curriculum.section.domain.Section;
-import com.lubycon.curriculum.section.model.IntroDescription;
-import com.lubycon.curriculum.section.repository.IntroSectionRepository;
-import com.lubycon.curriculum.section.repository.SectionRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.MediaType;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.ResultActions;
 
 class SectionApiTest extends ApiTest {
 
-  @Autowired
-  CurriculumRepository curriculumRepository;
-
-  @Autowired
-  SectionRepository sectionRepository;
-
-  @Autowired
-  BlogRepository blogRepository;
-
-  @Autowired
-  IntroSectionRepository introSectionRepository;
-
+  @Sql("/make-curriculum.sql")
   @DisplayName("특정 섹션의 내용을 가져온다.")
   @Test
   public void getSectionTest() throws Exception {
     // given
     String url = "/curriculums/{curriculumId}/sections/{sectionId}";
 
-    Curriculum curriculum = generateCurriculum();
-    Section section = generateSection(curriculum, 0);
-    Section nextSection = generateSection(curriculum, 1);
-    Blog blog = generateBlog(section);
-
     // when
-    mockMvc.perform(get(url, curriculum.getId(), section.getId())
-        .characterEncoding("UTF-8")
-        .accept(MediaType.APPLICATION_JSON))
-        .andExpect(status().isOk())  // then
-        .andExpect(jsonPath("$[0].title").value(section.getTitle()))
-        .andExpect(jsonPath("$[0].description").value(section.getDescription()))
-        .andExpect(jsonPath("$[0].blogs[0].title").value(blog.getTitle()))
-        .andExpect(jsonPath("$[0].nextSection.title").value(nextSection.getTitle()));
+    final ResultActions resultActions = mockMvc.perform(get(url, 1, 1));
+
+    // then
+    resultActions
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].title").value("1번 커리큘럼의 섹션1"))
+        .andExpect(jsonPath("$[0].description").value("1번 커리큘럼의 1번 섹션입니다."))
+        .andExpect(jsonPath("$[0].blogs[0].title").value("1번 섹션의 블로그 제목1"))
+        .andExpect(jsonPath("$[0].nextSection.title").value("1번 커리큘럼의 섹션2"));
   }
 
-
-  private Curriculum generateCurriculum() {
-    Curriculum curriculum = Curriculum.builder()
-        .title("커리큘럼 제목")
-        .description("커리큘럼 설명")
-        .thumbnail("커리큘럼 썸네일")
-        .build();
-
-    return curriculumRepository.save(curriculum);
-  }
-
-  private IntroSection generateIntroSection(Curriculum curriculum) {
-    IntroSection introSection = IntroSection.builder()
-        .description(IntroDescription.builder()
-            .summary("인트로 요약")
-            .description("인트로 설명")
-            .build())
-        .curriculum(curriculum)
-        .build();
-
-    return introSectionRepository.save(introSection);
-  }
-
-  private Section generateSection(Curriculum curriculum, int order) {
-    Section section = Section.builder()
-        .order(order)
-        .title("섹션 제목" + order)
-        .description("섹션 설명" + order)
-        .curriculum(curriculum)
-        .build();
-
-    return sectionRepository.save(section);
-  }
-
-  private Blog generateBlog(Section section) {
-    Blog blog = Blog.builder()
-        .section(section)
-        .link("블로그 링크")
-        .title("블로그 제목")
-        .build();
-
-    return blogRepository.save(blog);
-  }
 }

--- a/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
@@ -1,0 +1,101 @@
+package com.lubycon.curriculum.section.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.lubycon.curriculum.base.ApiTest;
+import com.lubycon.curriculum.blog.domain.Blog;
+import com.lubycon.curriculum.blog.repository.BlogRepository;
+import com.lubycon.curriculum.curriculum.domain.Curriculum;
+import com.lubycon.curriculum.curriculum.repository.CurriculumRepository;
+import com.lubycon.curriculum.section.domain.IntroSection;
+import com.lubycon.curriculum.section.domain.Section;
+import com.lubycon.curriculum.section.model.IntroDescription;
+import com.lubycon.curriculum.section.repository.IntroSectionRepository;
+import com.lubycon.curriculum.section.repository.SectionRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.MediaType;
+
+class SectionApiTest extends ApiTest {
+
+  @Autowired
+  CurriculumRepository curriculumRepository;
+
+  @Autowired
+  SectionRepository sectionRepository;
+
+  @Autowired
+  BlogRepository blogRepository;
+
+  @Autowired
+  IntroSectionRepository introSectionRepository;
+
+  @DisplayName("특정 섹션의 내용을 가져온다.")
+  @Test
+  public void getSectionTest() throws Exception {
+    // given
+    String url = "/curriculums/{curriculumId}/sections/{sectionId}";
+
+    Curriculum curriculum = generateCurriculum();
+    Section section = generateSection(curriculum, 0);
+    Section nextSection = generateSection(curriculum, 1);
+    Blog blog = generateBlog(section);
+
+    // when
+    mockMvc.perform(get(url, curriculum.getId(), section.getId())
+        .characterEncoding("UTF-8")
+        .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())  // then
+        .andExpect(jsonPath("$[0].title").value(section.getTitle()))
+        .andExpect(jsonPath("$[0].description").value(section.getDescription()))
+        .andExpect(jsonPath("$[0].blogs[0].title").value(blog.getTitle()))
+        .andExpect(jsonPath("$[0].nextSection.title").value(nextSection.getTitle()));
+  }
+
+
+  private Curriculum generateCurriculum() {
+    Curriculum curriculum = Curriculum.builder()
+        .title("커리큘럼 제목")
+        .description("커리큘럼 설명")
+        .thumbnail("커리큘럼 썸네일")
+        .build();
+
+    return curriculumRepository.save(curriculum);
+  }
+
+  private IntroSection generateIntroSection(Curriculum curriculum) {
+    IntroSection introSection = IntroSection.builder()
+        .description(IntroDescription.builder()
+            .summary("인트로 요약")
+            .description("인트로 설명")
+            .build())
+        .curriculum(curriculum)
+        .build();
+
+    return introSectionRepository.save(introSection);
+  }
+
+  private Section generateSection(Curriculum curriculum, int order) {
+    Section section = Section.builder()
+        .order(order)
+        .title("섹션 제목" + order)
+        .description("섹션 설명" + order)
+        .curriculum(curriculum)
+        .build();
+
+    return sectionRepository.save(section);
+  }
+
+  private Blog generateBlog(Section section) {
+    Blog blog = Blog.builder()
+        .section(section)
+        .link("블로그 링크")
+        .title("블로그 제목")
+        .build();
+
+    return blogRepository.save(blog);
+  }
+}

--- a/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
@@ -25,10 +25,11 @@ class SectionApiTest extends ApiTest {
     // then
     resultActions
         .andExpect(status().isOk())
-        .andExpect(jsonPath("$[0].title").value("1번 커리큘럼의 섹션1"))
-        .andExpect(jsonPath("$[0].description").value("1번 커리큘럼의 1번 섹션입니다."))
-        .andExpect(jsonPath("$[0].blogs[0].title").value("1번 섹션의 블로그 제목1"))
-        .andExpect(jsonPath("$[0].nextSection.title").value("1번 커리큘럼의 섹션2"));
+        .andExpect(jsonPath("$.title").value("1번 커리큘럼의 섹션2"))
+        .andExpect(jsonPath("$.description").value("1번 커리큘럼의 2번 섹션입니다."))
+        .andExpect(jsonPath("$.blogs[0].title").value("2번 섹션의 블로그 제목1"))
+        .andExpect(jsonPath("$.nextSection").isEmpty())
+        .andExpect(jsonPath("$.prevSection.title").value("1번 커리큘럼의 섹션1"));
   }
 
 }

--- a/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/api/SectionApiTest.java
@@ -26,6 +26,7 @@ class SectionApiTest extends ApiTest {
     resultActions
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.title").value("1번 커리큘럼의 섹션2"))
+        .andExpect(jsonPath("$.order").value(1))
         .andExpect(jsonPath("$.description").value("1번 커리큘럼의 2번 섹션입니다."))
         .andExpect(jsonPath("$.blogs[0].title").value("2번 섹션의 블로그 제목1"))
         .andExpect(jsonPath("$.nextSection").isEmpty())

--- a/src/test/java/com/lubycon/curriculum/section/repository/SectionRepositoryTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/repository/SectionRepositoryTest.java
@@ -15,7 +15,6 @@ class SectionRepositoryTest extends RepositoryTest {
   @Autowired
   private SectionRepository sectionRepository;
 
-
   @Sql("/make-curriculum.sql")
   @DisplayName("findById() 테스트")
   @Test
@@ -27,5 +26,14 @@ class SectionRepositoryTest extends RepositoryTest {
     assertThat(findBlog.getLink()).isEqualTo("1번 섹션의 블로그 링크1");
   }
 
+  @Sql("/make-curriculum.sql")
+  @DisplayName("커리큘럼의 아이디와 순서로 해당하는 섹션을 찾을 수 있다.")
+  @Test
+  public void findByCurriculumIdAndOrderTest() {
+    Section findSection = sectionRepository.findByCurriculumIdAndOrder(1L, 1).get();
+
+    assertThat(findSection.getTitle()).isEqualTo("1번 커리큘럼의 섹션2");
+    assertThat(findSection.getDescription()).isEqualTo("1번 커리큘럼의 2번 섹션입니다.");
+  }
 
 }

--- a/src/test/java/com/lubycon/curriculum/section/repository/SectionRepositoryTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/repository/SectionRepositoryTest.java
@@ -8,20 +8,23 @@ import com.lubycon.curriculum.section.domain.Section;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
 
 class SectionRepositoryTest extends RepositoryTest {
 
   @Autowired
   private SectionRepository sectionRepository;
 
+
+  @Sql("/make-curriculum.sql")
   @DisplayName("findById() 테스트")
   @Test
   public void findById() {
     Section findSection = sectionRepository.findById(1L).get();
 
     Blog findBlog = findSection.getBlogs().get(0);
-    assertThat(findBlog.getTitle()).isEqualTo("제목");
-    assertThat(findBlog.getLink()).isEqualTo("링크1");
+    assertThat(findBlog.getTitle()).isEqualTo("1번 섹션의 블로그 제목1");
+    assertThat(findBlog.getLink()).isEqualTo("1번 섹션의 블로그 링크1");
   }
 
 

--- a/src/test/java/com/lubycon/curriculum/section/service/SectionServiceTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/service/SectionServiceTest.java
@@ -25,9 +25,10 @@ class SectionServiceTest {
     SectionResponse findSection = sectionService.findSection(1, 1);
 
     // then
-    assertThat(findSection.getTitle()).isEqualTo("1번 커리큘럼의 섹션1");
-    assertThat(findSection.getDescription()).isEqualTo("1번 커리큘럼의 1번 섹션입니다.");
-    assertThat(findSection.getBlogs().get(0).getTitle()).isEqualTo("1번 섹션의 블로그 제목1");
-    assertThat(findSection.getNextSection().getTitle()).isEqualTo("1번 커리큘럼의 섹션2");
+    assertThat(findSection.getTitle()).isEqualTo("1번 커리큘럼의 섹션2");
+    assertThat(findSection.getDescription()).isEqualTo("1번 커리큘럼의 2번 섹션입니다.");
+    assertThat(findSection.getBlogs().get(0).getTitle()).isEqualTo("2번 섹션의 블로그 제목1");
+    assertThat(findSection.getPrevSection().getTitle()).isEqualTo("1번 커리큘럼의 섹션1");
+    assertThat(findSection.getNextSection()).isNull();
   }
 }

--- a/src/test/java/com/lubycon/curriculum/section/service/SectionServiceTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/service/SectionServiceTest.java
@@ -26,6 +26,7 @@ class SectionServiceTest {
 
     // then
     assertThat(findSection.getTitle()).isEqualTo("1번 커리큘럼의 섹션2");
+    assertThat(findSection.getOrder()).isEqualTo(1);
     assertThat(findSection.getDescription()).isEqualTo("1번 커리큘럼의 2번 섹션입니다.");
     assertThat(findSection.getBlogs().get(0).getTitle()).isEqualTo("2번 섹션의 블로그 제목1");
     assertThat(findSection.getPrevSection().getTitle()).isEqualTo("1번 커리큘럼의 섹션1");

--- a/src/test/java/com/lubycon/curriculum/section/service/SectionServiceTest.java
+++ b/src/test/java/com/lubycon/curriculum/section/service/SectionServiceTest.java
@@ -1,0 +1,33 @@
+package com.lubycon.curriculum.section.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.lubycon.curriculum.section.dto.SectionResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@SpringBootTest
+class SectionServiceTest {
+
+  @Autowired
+  SectionService sectionService;
+
+  @Sql("/make-curriculum.sql")
+  @DisplayName("특정 섹션의 내용을 가져온다.")
+  @Test
+  public void getSectionTest() {
+    // when
+    SectionResponse findSection = sectionService.findSection(1, 1);
+
+    // then
+    assertThat(findSection.getTitle()).isEqualTo("1번 커리큘럼의 섹션1");
+    assertThat(findSection.getDescription()).isEqualTo("1번 커리큘럼의 1번 섹션입니다.");
+    assertThat(findSection.getBlogs().get(0).getTitle()).isEqualTo("1번 섹션의 블로그 제목1");
+    assertThat(findSection.getNextSection().getTitle()).isEqualTo("1번 커리큘럼의 섹션2");
+  }
+}

--- a/src/test/resources/data.sql
+++ b/src/test/resources/data.sql
@@ -1,9 +1,0 @@
-INSERT INTO curriculum (id, title, description, thumbnail) VALUES (1, '제목', '설명', '썸네일')
-
-INSERT INTO section (id, curriculum_id, description) VALUES (1, 1, '설명')
-
-INSERT INTO blog (section_id, title, link) VALUES (1, '제목', '링크1')
-INSERT INTO blog (section_id, title, link) VALUES (1, '제목2', '링크2')
-
-INSERT INTO intro_section (id, curriculum_id, summary, description) VALUES (1, 1, '핵심 설명', '설명')
-

--- a/src/test/resources/make-curriculum.sql
+++ b/src/test/resources/make-curriculum.sql
@@ -1,0 +1,10 @@
+INSERT INTO curriculum (id, title, description, thumbnail) VALUES (1, '1번 커리큘럼의 제목', '1번 커리큘럼의 설명', '1번 커리큘럼의 썸네일')
+
+INSERT INTO section (id, curriculum_id, order_by, title, description) VALUES (1, 1, 0, '1번 커리큘럼의 섹션1', '1번 커리큘럼의 1번 섹션입니다.')
+INSERT INTO section (id, curriculum_id, order_by, title, description) VALUES (2, 1, 1, '1번 커리큘럼의 섹션2', '1번 커리큘럼의 2번 섹션입니다.')
+
+INSERT INTO blog (id, section_id, title, link) VALUES (1, 1, '1번 섹션의 블로그 제목1', '1번 섹션의 블로그 링크1')
+INSERT INTO blog (id, section_id, title, link) VALUES (2, 1, '1번 섹션의 블로그 제목2', '1번 섹션의 블로그 링크2')
+INSERT INTO blog (id, section_id, title, link) VALUES (3, 2, '2번 섹션의 블로그 제목1', '2번 섹션의 블로그 링크1')
+
+INSERT INTO intro_section (id, curriculum_id, summary, description) VALUES (1, 1, '1번 커리큘럼의 핵심 설명', '1번 커리큘럼의 설명')


### PR DESCRIPTION
## 내용

<!--
- 스샷을 첨부해주세요.
- 추가된 기능들의 나열.
- 포인트: 최대한 자세히 쓸 것. 내 코드 보는 사람은 지금 이 도메인 맥락을 모른다고 가정하기
- 코드에 셀프 코멘트를 달아주면 좋음!
-->

[API 정의서](https://app.swaggerhub.com/apis/sun15/curriculum/1.0.0#free)를 바탕으로 작성한 API로, **특정 섹션의 내용을 가져오는 API**입니다. 

## 특별히 봐줬으면 하는 부분
```
  private NextSectionResponse findNextSection(long curriculumId, int order) {
    return sectionRepository.findByCurriculumIdAndOrder(curriculumId, order + 1)
        .map(NextSectionResponse::fromEntity)
        .orElse(null);
  }
```
다음 섹션이 존재하지 않는다면 null을 반환하게 처리했는데, 이렇게 해도 괜찮을지 긴가민가하네요 ㅠ.ㅠ 
클린 코드에서는 [null을 리턴하지 말라](https://eglowc.tistory.com/42)고 하는데, 빈 객체를 만들어서 리턴하는게 더 나을지, 그대로 둬도 괜찮을지, 이 부분 관련해서 의견 주시면 감사하겠습니당 🙏 
<!-- 셀프 코멘트도 달아주세요! -->

## 참고 사항
예외 발생 시 메세지를 정의하지 않아 예외 처리는 해두지 않고 `FIXME`로 달아두었습니다! 이 부분은 에러 메세지 정의 및 상태 코드 정의가 완료되면 별도로 이슈를 만들어서 처리할 예정입니다.
<!-- PR을 리뷰할 때 중점적으로 리뷰가 필요하거나 참고가 필요한 내용을 적어주세요. -->
resolved #9